### PR TITLE
Add blog:win:db script for running docker compose on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,26 +6,22 @@
   "scripts": {
     "pb:gen": "./scripts/gen.sh greet calculator blog",
     "pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 greet calculator blog",
-
     "greet:server": "node greet/server/index.js",
     "greet:client": "node greet/client/index.js",
     "greet:pb:gen": "./scripts/gen.sh greet",
     "greet:pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 greet",
-
     "calculator:server": "node calculator/server/index.js",
     "calculator:client": "node calculator/client/index.js",
     "calculator:pb:gen": "./scripts/gen.sh calculator",
     "calculator:pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 calculator",
-
     "blog:db": "cd blog; docker-compose up; cd ..",
+    "blog:win:db": "cd blog && docker-compose up && cd ..",
     "blog:server": "node blog/server/index.js",
     "blog:client": "node blog/client/index.js",
     "blog:pb:gen": "./scripts/gen.sh blog",
     "blog:pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 blog",
-
     "ssl:gen": "cd ssl && ../scripts/ssl.sh && cd ..",
     "ssl:win:gen": "cd ssl && powershell -ExecutionPolicy unrestricted ../scripts/ssl.ps1 && cd ..",
-
     "clean": "find . -type f -name '*_pb.js' -not -path './node_modules/**/*_pb.js' -delete && rm ssl/*.crt ssl/*.key ssl/*.csr ssl/*.pem",
     "clean:win": "powershell \"Get-ChildItem -Filter *_pb.js -Recurse $pwd | Foreach-Object { if ($_.FullName -inotmatch 'node_modules') { rm $_.FullName  } }\" && powershell Remove-Item ssl/*.crt, ssl/*.key, ssl/*.csr, ssl/*.pem",
     "bump": "ncu -u && npm install",

--- a/package.json
+++ b/package.json
@@ -6,22 +6,27 @@
   "scripts": {
     "pb:gen": "./scripts/gen.sh greet calculator blog",
     "pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 greet calculator blog",
+
     "greet:server": "node greet/server/index.js",
     "greet:client": "node greet/client/index.js",
     "greet:pb:gen": "./scripts/gen.sh greet",
     "greet:pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 greet",
+
     "calculator:server": "node calculator/server/index.js",
     "calculator:client": "node calculator/client/index.js",
     "calculator:pb:gen": "./scripts/gen.sh calculator",
     "calculator:pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 calculator",
+
     "blog:db": "cd blog; docker-compose up; cd ..",
     "blog:win:db": "cd blog && docker-compose up && cd ..",
     "blog:server": "node blog/server/index.js",
     "blog:client": "node blog/client/index.js",
     "blog:pb:gen": "./scripts/gen.sh blog",
     "blog:pb:win:gen": "powershell -ExecutionPolicy unrestricted ./scripts/gen.ps1 blog",
+
     "ssl:gen": "cd ssl && ../scripts/ssl.sh && cd ..",
     "ssl:win:gen": "cd ssl && powershell -ExecutionPolicy unrestricted ../scripts/ssl.ps1 && cd ..",
+
     "clean": "find . -type f -name '*_pb.js' -not -path './node_modules/**/*_pb.js' -delete && rm ssl/*.crt ssl/*.key ssl/*.csr ssl/*.pem",
     "clean:win": "powershell \"Get-ChildItem -Filter *_pb.js -Recurse $pwd | Foreach-Object { if ($_.FullName -inotmatch 'node_modules') { rm $_.FullName  } }\" && powershell Remove-Item ssl/*.crt, ssl/*.key, ssl/*.csr, ssl/*.pem",
     "bump": "ncu -u && npm install",


### PR DESCRIPTION
In npm scripts on Windows 'cd' doesn't work the same way as on Linux.  The && or ; chaining with 'cd' behaves differently in the Windows command prompt.